### PR TITLE
#Hotfix 160 - Corrigir Hover do Botão de Voto no PWA

### DIFF
--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -154,7 +154,6 @@
 
 	&__upvote:hover {
 		cursor: pointer;
-		opacity: 80%;
 	}
 	
 


### PR DESCRIPTION
## Conteúdo
Foi corrigido o hover no botão de voto do pwa, não desaparecendo mais, quando é realizado um voto.